### PR TITLE
Add basic UI components and refactor usage

### DIFF
--- a/src/components/CreateTaskDialog.tsx
+++ b/src/components/CreateTaskDialog.tsx
@@ -3,6 +3,7 @@ import { ApiClient } from "../lib/api-client";
 import { useTaskStore } from "../lib/task-store";
 import type { TaskPriority } from "../lib/types";
 import { toast } from "react-hot-toast";
+import { Input, Button } from "../ui";
 
 interface Props {
   open: boolean;
@@ -63,9 +64,8 @@ export const CreateTaskDialog: React.FC<Props> = ({ open, onClose }) => {
             <label className="block text-sm mb-1" htmlFor="title">
               Title
             </label>
-            <input
+            <Input
               id="title"
-              className="w-full border rounded-md p-2"
               value={title}
               onChange={(e) => setTitle(e.target.value)}
               required
@@ -102,31 +102,27 @@ export const CreateTaskDialog: React.FC<Props> = ({ open, onClose }) => {
             <label className="block text-sm mb-1" htmlFor="due">
               Due Date
             </label>
-            <input
+            <Input
               id="due"
               type="date"
-              className="w-full border rounded-md p-2"
               value={dueDate}
               onChange={(e) => setDueDate(e.target.value)}
               required
             />
           </div>
           <div className="flex justify-end gap-2 pt-2">
-            <button
-              type="button"
-              onClick={onClose}
-              className="px-3 py-1 border rounded"
-            >
+            <Button type="button" onClick={onClose}
+              className="px-3 py-1">
               Cancel
-            </button>
-            <button
+            </Button>
+            <Button
               type="submit"
               disabled={loading}
-              className="px-3 py-1 border rounded bg-blue-600 text-white disabled:opacity-50"
+              className="px-3 py-1 bg-blue-600 text-white disabled:opacity-50"
             >
               {loading ? "Saving..." : "Create"}
-            </button>
-          </div>
+            </Button>
+         </div>
         </form>
       </div>
     </div>

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { useAuth } from "../context/AuthContext";
 import { toast } from "react-hot-toast";
+import { Input, Button } from "../ui";
 
 export const LoginForm: React.FC = () => {
   const [email, setEmail] = useState("");
@@ -26,10 +27,9 @@ export const LoginForm: React.FC = () => {
         <label htmlFor="email" className="block text-sm font-medium">
           Email
         </label>
-        <input
+        <Input
           id="email"
           type="email"
-          className="w-full border rounded-md p-2"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
           required
@@ -39,22 +39,21 @@ export const LoginForm: React.FC = () => {
         <label htmlFor="password" className="block text-sm font-medium">
           Password
         </label>
-        <input
+        <Input
           id="password"
           type="password"
-          className="w-full border rounded-md p-2"
           value={password}
           onChange={(e) => setPassword(e.target.value)}
           required
         />
       </div>
-      <button
+      <Button
         type="submit"
-        className="w-full py-2 bg-green-700 text-white rounded-md"
+        className="w-full py-2 bg-green-700 text-white"
         disabled={isLoading}
       >
         {isLoading ? "Loading..." : "Login"}
-      </button>
+      </Button>
     </form>
   );
 };

--- a/src/components/RegisterForm.tsx
+++ b/src/components/RegisterForm.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { useAuth } from "../context/AuthContext";
 import { toast } from "react-hot-toast";
+import { Input, Button } from "../ui";
 
 export const RegisterForm: React.FC = () => {
   const [name, setName] = useState("");
@@ -31,10 +32,9 @@ export const RegisterForm: React.FC = () => {
         <label htmlFor="name" className="block text-sm font-medium">
           Name
         </label>
-        <input
+        <Input
           id="name"
           type="text"
-          className="w-full border rounded-md p-2"
           value={name}
           onChange={(e) => setName(e.target.value)}
           required
@@ -44,10 +44,9 @@ export const RegisterForm: React.FC = () => {
         <label htmlFor="email" className="block text-sm font-medium">
           Email
         </label>
-        <input
+        <Input
           id="email"
           type="email"
-          className="w-full border rounded-md p-2"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
           required
@@ -57,22 +56,21 @@ export const RegisterForm: React.FC = () => {
         <label htmlFor="password" className="block text-sm font-medium">
           Password
         </label>
-        <input
+        <Input
           id="password"
           type="password"
-          className="w-full border rounded-md p-2"
           value={password}
           onChange={(e) => setPassword(e.target.value)}
           required
         />
       </div>
-      <button
+      <Button
         type="submit"
-        className="w-full py-2 bg-green-700 text-white rounded-md"
+        className="w-full py-2 bg-green-700 text-white"
         disabled={isLoading}
       >
         {isLoading ? "Loading..." : "Create Account"}
-      </button>
+      </Button>
     </form>
   );
 };

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -4,6 +4,7 @@ import { Task } from "../lib/types";
 import { ApiClient } from "../lib/api-client";
 import { EditTaskDialog } from "./EditTaskDialog";
 import { toast } from "react-hot-toast";
+import { Card, Button } from "../ui";
 
 export const TaskCard: React.FC<{ task: Task; onUpdate: () => void }> = ({
   task,
@@ -62,7 +63,7 @@ export const TaskCard: React.FC<{ task: Task; onUpdate: () => void }> = ({
   };
 
   return (
-    <div className="border rounded-md p-4 shadow-sm hover:shadow-md transition-shadow relative">
+    <Card className="shadow-sm hover:shadow-md transition-shadow relative">
       <div className="flex flex-col sm:flex-row items-start justify-between gap-4">
         <div className="flex-1">
           <h3 className="font-semibold text-lg mb-2 break-words">
@@ -88,34 +89,34 @@ export const TaskCard: React.FC<{ task: Task; onUpdate: () => void }> = ({
           </div>
           <div className="flex gap-2 mb-2">
             {task.status !== "completed" && (
-              <button
+              <Button
                 onClick={() => handleStatusChange("completed")}
-                className="px-2 py-1 text-sm border rounded"
+                className="px-2 py-1 text-sm"
               >
                 Mark Complete
-              </button>
+              </Button>
             )}
             {task.status === "pending" && (
-              <button
+              <Button
                 onClick={() => handleStatusChange("in-progress")}
-                className="px-2 py-1 text-sm border rounded"
+                className="px-2 py-1 text-sm"
               >
                 Start
-              </button>
+              </Button>
             )}
           </div>
         </div>
         <div className="relative">
-          <button
+          <Button
             onClick={() => setMenuOpen((o) => !o)}
-            className="p-1 border rounded"
+            className="p-1"
             aria-label="Menu"
           >
             <MoreHorizontal className="h-4 w-4" />
-          </button>
+          </Button>
           {menuOpen && (
             <div className="absolute right-0 mt-2 border bg-white rounded shadow-md text-sm z-10">
-              <button
+              <Button
                 onClick={() => {
                   setShowEdit(true);
                   setMenuOpen(false);
@@ -123,13 +124,13 @@ export const TaskCard: React.FC<{ task: Task; onUpdate: () => void }> = ({
                 className="block px-4 py-2 hover:bg-gray-100 w-full text-left"
               >
                 Edit
-              </button>
-              <button
+              </Button>
+              <Button
                 onClick={handleDelete}
                 className="block px-4 py-2 hover:bg-gray-100 w-full text-left text-red-600"
               >
                 Delete
-              </button>
+              </Button>
             </div>
           )}
         </div>
@@ -139,6 +140,6 @@ export const TaskCard: React.FC<{ task: Task; onUpdate: () => void }> = ({
         open={showEdit}
         onClose={() => setShowEdit(false)}
       />
-    </div>
+    </Card>
   );
 };

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -13,7 +13,7 @@ export const TaskList: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [page, setPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
-  const { filters, notifyUpdate } = useTaskStore();
+  const { filters, notifyUpdate, lastUpdated } = useTaskStore();
 
   useEffect(() => {
     setPage(1);
@@ -42,10 +42,9 @@ export const TaskList: React.FC = () => {
 
   useEffect(() => {
     fetchTasks();
-  }, [fetchTasks]);
+  }, [fetchTasks, lastUpdated]);
 
   const handleTaskUpdate = () => {
-    fetchTasks();
     notifyUpdate();
   };
 

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -4,6 +4,7 @@ import { Task, TaskListResponse } from '../lib/types';
 import { useTaskStore } from '../lib/task-store';
 import { TaskCard } from './TaskCard';
 import { TaskFilterBar } from './TaskFilterBar';
+import { Button } from '../ui';
 
 const PAGE_SIZE = 20;
 
@@ -69,21 +70,21 @@ export const TaskList: React.FC = () => {
       )}
       {totalPages > 1 && (
         <div className="mt-4 flex justify-center gap-2">
-          <button
+          <Button
             onClick={() => setPage((p) => Math.max(1, p - 1))}
             disabled={page === 1}
-            className="px-3 py-1 border rounded disabled:opacity-50"
+            className="disabled:opacity-50"
           >
             Previous
-          </button>
+          </Button>
           <span className="px-3 py-1 text-sm font-medium">{page}</span>
-          <button
+          <Button
             onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
             disabled={page === totalPages}
-            className="px-3 py-1 border rounded disabled:opacity-50"
+            className="disabled:opacity-50"
           >
             Next
-          </button>
+          </Button>
         </div>
       )}
     </div>

--- a/src/ui/Button.tsx
+++ b/src/ui/Button.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+
+export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement>;
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className = "", children, ...props }, ref) => (
+    <button
+      ref={ref}
+      className={`px-3 py-1 border rounded ${className}`}
+      {...props}
+    >
+      {children}
+    </button>
+  )
+);
+Button.displayName = "Button";

--- a/src/ui/Card.tsx
+++ b/src/ui/Card.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+export type CardProps = React.HTMLAttributes<HTMLDivElement>;
+
+export const Card: React.FC<CardProps> = ({ className = "", children, ...props }) => (
+  <div className={`bg-white border rounded-md p-4 shadow-sm ${className}`} {...props}>
+    {children}
+  </div>
+);

--- a/src/ui/Input.tsx
+++ b/src/ui/Input.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+export const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className = "", ...props }, ref) => (
+    <input
+      ref={ref}
+      className={`w-full border rounded-md p-2 ${className}`}
+      {...props}
+    />
+  )
+);
+Input.displayName = "Input";

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -1,0 +1,3 @@
+export * from "./Button";
+export * from "./Input";
+export * from "./Card";


### PR DESCRIPTION
## Summary
- create reusable `Button`, `Input`, and `Card` components
- re-export UI components from a single entry point
- refactor login/register forms to use the new UI
- use new UI in `TaskCard` and `TaskList`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dc73442b08333bd51ed97544f8210