### PR TITLE
Refactor forms to use reusable task form

### DIFF
--- a/src/components/CreateTaskDialog.tsx
+++ b/src/components/CreateTaskDialog.tsx
@@ -1,9 +1,8 @@
-import React, { useState } from "react";
+import React from "react";
 import { ApiClient } from "../lib/api-client";
 import { useTaskStore } from "../lib/task-store";
-import type { TaskPriority } from "../lib/types";
 import { toast } from "react-hot-toast";
-import { Input, Button } from "./ui";
+import { TaskForm, TaskFormValues } from "./TaskForm";
 
 interface Props {
   open: boolean;
@@ -11,47 +10,19 @@ interface Props {
 }
 
 export const CreateTaskDialog: React.FC<Props> = ({ open, onClose }) => {
-  const [title, setTitle] = useState("");
-  const [description, setDescription] = useState("");
-  const [priority, setPriority] = useState<TaskPriority>("medium");
-  const [dueDate, setDueDate] = useState("");
-  const [loading, setLoading] = useState(false);
   const notifyUpdate = useTaskStore((s) => s.notifyUpdate);
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (dueDate) {
-      const selected = new Date(dueDate);
-      selected.setHours(0, 0, 0, 0);
-      const today = new Date();
-      today.setHours(0, 0, 0, 0);
-      if (selected < today) {
-        toast.error("Due date cannot be in the past");
-        return;
-      }
-    }
-    setLoading(true);
-    try {
-      await ApiClient.createTask({
-        title,
-        description,
-        priority,
-        dueDate: dueDate,
-        status: "pending",
-      } as any);
-      notifyUpdate();
-      setTitle("");
-      setDescription("");
-      setPriority("medium");
-      setDueDate("");
-      onClose();
-      toast.success("Task created");
-    } catch (err) {
-      console.error("Failed to create task", err);
-      toast.error("Failed to create task");
-    } finally {
-      setLoading(false);
-    }
+  const handleSubmit = async (values: TaskFormValues) => {
+    await ApiClient.createTask({
+      title: values.title,
+      description: values.description,
+      priority: values.priority,
+      dueDate: values.dueDate,
+      status: "pending",
+    } as any);
+    notifyUpdate();
+    onClose();
+    toast.success("Task created");
   };
 
   if (!open) return null;
@@ -59,70 +30,13 @@ export const CreateTaskDialog: React.FC<Props> = ({ open, onClose }) => {
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
       <div className="bg-white rounded-md p-6 w-96">
         <h2 className="text-lg font-semibold mb-4">Create New Task</h2>
-        <form onSubmit={handleSubmit} className="space-y-3">
-          <div>
-            <label className="block text-sm mb-1" htmlFor="title">
-              Title
-            </label>
-            <Input
-              id="title"
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              required
-            />
-          </div>
-          <div>
-            <label className="block text-sm mb-1" htmlFor="description">
-              Description
-            </label>
-            <textarea
-              id="description"
-              className="w-full border rounded-md p-2"
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              required
-            />
-          </div>
-          <div>
-            <label className="block text-sm mb-1" htmlFor="priority">
-              Priority
-            </label>
-            <select
-              id="priority"
-              className="w-full border rounded-md p-2"
-              value={priority}
-              onChange={(e) => setPriority(e.target.value as any)}
-            >
-              <option value="low">Low</option>
-              <option value="medium">Medium</option>
-              <option value="high">High</option>
-            </select>
-          </div>
-          <div>
-            <label className="block text-sm mb-1" htmlFor="due">
-              Due Date
-            </label>
-            <Input
-              id="due"
-              type="date"
-              value={dueDate}
-              onChange={(e) => setDueDate(e.target.value)}
-              required
-            />
-          </div>
-          <div className="flex justify-end gap-2 pt-2">
-            <Button type="button" onClick={onClose} className="px-3 py-1">
-              Cancel
-            </Button>
-            <Button
-              type="submit"
-              disabled={loading}
-              className="px-3 py-1 bg-green-700 text-white disabled:opacity-50"
-            >
-              {loading ? "Saving..." : "Create"}
-            </Button>
-          </div>
-        </form>
+        <TaskForm
+          submitLabel="Create"
+          requireDescription
+          requireDueDate
+          onCancel={onClose}
+          onSubmit={handleSubmit}
+        />
       </div>
     </div>
   );

--- a/src/components/EditTaskDialog.tsx
+++ b/src/components/EditTaskDialog.tsx
@@ -1,8 +1,9 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import { ApiClient } from "../lib/api-client";
-import { Task, TaskPriority } from "../lib/types";
+import { Task } from "../lib/types";
 import { useTaskStore } from "../lib/task-store";
 import { toast } from "react-hot-toast";
+import { TaskForm, TaskFormValues } from "./TaskForm";
 
 interface Props {
   task: Task;
@@ -11,56 +12,19 @@ interface Props {
 }
 
 export const EditTaskDialog: React.FC<Props> = ({ task, open, onClose }) => {
-  const [title, setTitle] = useState("");
-  const [description, setDescription] = useState("");
-  const [priority, setPriority] = useState<TaskPriority>("medium");
-  const [status, setStatus] = useState<"pending" | "in-progress" | "completed">(
-    "pending"
-  );
-  const [dueDate, setDueDate] = useState("");
-  const [loading, setLoading] = useState(false);
   const notifyUpdate = useTaskStore((s) => s.notifyUpdate);
 
-  useEffect(() => {
-    if (open) {
-      setTitle(task.title);
-      setDescription(task.description || "");
-      setPriority(task.priority);
-      setStatus(task.status);
-      setDueDate(task.dueDate ? task.dueDate.split("T")[0] : "");
-    }
-  }, [open, task]);
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (dueDate) {
-      const selected = new Date(dueDate);
-      selected.setHours(0, 0, 0, 0);
-      const today = new Date();
-      today.setHours(0, 0, 0, 0);
-      if (selected < today) {
-        toast.error("Due date cannot be in the past");
-        return;
-      }
-    }
-    setLoading(true);
-    try {
-      await ApiClient.updateTask(task.id, {
-        title,
-        description,
-        priority,
-        status,
-        dueDate: dueDate || undefined,
-      } as any);
-      notifyUpdate();
-      onClose();
-      toast.success("Task updated");
-    } catch (err) {
-      console.error("Failed to update task", err);
-      toast.error("Failed to update task");
-    } finally {
-      setLoading(false);
-    }
+  const handleSubmit = async (values: TaskFormValues) => {
+    await ApiClient.updateTask(task.id, {
+      title: values.title,
+      description: values.description,
+      priority: values.priority,
+      status: values.status!,
+      dueDate: values.dueDate || undefined,
+    } as any);
+    notifyUpdate();
+    onClose();
+    toast.success("Task updated");
   };
 
   if (!open) return null;
@@ -68,89 +32,19 @@ export const EditTaskDialog: React.FC<Props> = ({ task, open, onClose }) => {
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
       <div className="bg-white rounded-md p-6 w-96">
         <h2 className="text-lg font-semibold mb-4">Edit Task</h2>
-        <form onSubmit={handleSubmit} className="space-y-3">
-          <div>
-            <label className="block text-sm mb-1" htmlFor="title">
-              Title
-            </label>
-            <input
-              id="title"
-              className="w-full border rounded-md p-2"
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              required
-            />
-          </div>
-          <div>
-            <label className="block text-sm mb-1" htmlFor="description">
-              Description
-            </label>
-            <textarea
-              id="description"
-              className="w-full border rounded-md p-2"
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-            />
-          </div>
-          <div>
-            <label className="block text-sm mb-1" htmlFor="status">
-              Status
-            </label>
-            <select
-              id="status"
-              className="w-full border rounded-md p-2"
-              value={status}
-              onChange={(e) => setStatus(e.target.value as any)}
-            >
-              <option value="pending">Pending</option>
-              <option value="in-progress">In Progress</option>
-              <option value="completed">Completed</option>
-            </select>
-          </div>
-          <div>
-            <label className="block text-sm mb-1" htmlFor="priority">
-              Priority
-            </label>
-            <select
-              id="priority"
-              className="w-full border rounded-md p-2"
-              value={priority}
-              onChange={(e) => setPriority(e.target.value as any)}
-            >
-              <option value="low">Low</option>
-              <option value="medium">Medium</option>
-              <option value="high">High</option>
-            </select>
-          </div>
-          <div>
-            <label className="block text-sm mb-1" htmlFor="due">
-              Due Date
-            </label>
-            <input
-              id="due"
-              type="date"
-              className="w-full border rounded-md p-2"
-              value={dueDate}
-              onChange={(e) => setDueDate(e.target.value)}
-            />
-          </div>
-          <div className="flex justify-end gap-2 pt-2">
-            <button
-              type="button"
-              onClick={onClose}
-              className="px-3 py-1 border rounded"
-            >
-              Cancel
-            </button>
-            <button
-              type="submit"
-              disabled={loading}
-              className="px-3 py-1 border rounded bg-blue-600 text-white disabled:opacity-50"
-            >
-              {loading ? "Saving..." : "Update"}
-            </button>
-          </div>
-        </form>
+        <TaskForm
+          includeStatus
+          submitLabel="Update"
+          initialValues={{
+            title: task.title,
+            description: task.description || "",
+            priority: task.priority,
+            status: task.status,
+            dueDate: task.dueDate ? task.dueDate.split("T")[0] : "",
+          }}
+          onCancel={onClose}
+          onSubmit={handleSubmit}
+        />
       </div>
     </div>
   );

--- a/src/components/TaskForm.tsx
+++ b/src/components/TaskForm.tsx
@@ -1,0 +1,170 @@
+import React, { useState, useEffect } from "react";
+import { TaskPriority } from "../lib/types";
+import { Input, Button } from "./ui";
+import { toast } from "react-hot-toast";
+
+export interface TaskFormValues {
+  title: string;
+  description: string;
+  priority: TaskPriority;
+  status?: "pending" | "in-progress" | "completed";
+  dueDate: string;
+}
+
+interface TaskFormProps {
+  initialValues?: Partial<TaskFormValues>;
+  includeStatus?: boolean;
+  requireDescription?: boolean;
+  requireDueDate?: boolean;
+  submitLabel: string;
+  onSubmit: (values: TaskFormValues) => Promise<void> | void;
+  onCancel: () => void;
+}
+
+export const TaskForm: React.FC<TaskFormProps> = ({
+  initialValues = {},
+  includeStatus = false,
+  requireDescription = false,
+  requireDueDate = false,
+  submitLabel,
+  onSubmit,
+  onCancel,
+}) => {
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [priority, setPriority] = useState<TaskPriority>("medium");
+  const [status, setStatus] = useState<"pending" | "in-progress" | "completed">(
+    "pending"
+  );
+  const [dueDate, setDueDate] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    setTitle(initialValues.title || "");
+    setDescription(initialValues.description || "");
+    setPriority(initialValues.priority || "medium");
+    setStatus(initialValues.status || "pending");
+    setDueDate(
+      initialValues.dueDate ? initialValues.dueDate.split("T")[0] : ""
+    );
+  }, [initialValues]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (dueDate) {
+      const selected = new Date(dueDate);
+      selected.setHours(0, 0, 0, 0);
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+      if (selected < today) {
+        toast.error("Due date cannot be in the past");
+        return;
+      }
+    } else if (requireDueDate) {
+      toast.error("Due date is required");
+      return;
+    }
+
+    if (requireDescription && !description.trim()) {
+      toast.error("Description is required");
+      return;
+    }
+
+    setLoading(true);
+    try {
+      await onSubmit({
+        title,
+        description,
+        priority,
+        status: includeStatus ? status : undefined,
+        dueDate,
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-3">
+      <div>
+        <label className="block text-sm mb-1" htmlFor="title">
+          Title
+        </label>
+        <Input
+          id="title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          required
+        />
+      </div>
+      <div>
+        <label className="block text-sm mb-1" htmlFor="description">
+          Description
+        </label>
+        <textarea
+          id="description"
+          className="w-full border rounded-md p-2"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          required={requireDescription}
+        />
+      </div>
+      {includeStatus && (
+        <div>
+          <label className="block text-sm mb-1" htmlFor="status">
+            Status
+          </label>
+          <select
+            id="status"
+            className="w-full border rounded-md p-2"
+            value={status}
+            onChange={(e) => setStatus(e.target.value as any)}
+          >
+            <option value="pending">Pending</option>
+            <option value="in-progress">In Progress</option>
+            <option value="completed">Completed</option>
+          </select>
+        </div>
+      )}
+      <div>
+        <label className="block text-sm mb-1" htmlFor="priority">
+          Priority
+        </label>
+        <select
+          id="priority"
+          className="w-full border rounded-md p-2"
+          value={priority}
+          onChange={(e) => setPriority(e.target.value as any)}
+        >
+          <option value="low">Low</option>
+          <option value="medium">Medium</option>
+          <option value="high">High</option>
+        </select>
+      </div>
+      <div>
+        <label className="block text-sm mb-1" htmlFor="due">
+          Due Date
+        </label>
+        <Input
+          id="due"
+          type="date"
+          value={dueDate}
+          onChange={(e) => setDueDate(e.target.value)}
+          required={requireDueDate}
+        />
+      </div>
+      <div className="flex justify-end gap-2 pt-2">
+        <Button type="button" onClick={onCancel} className="px-3 py-1">
+          Cancel
+        </Button>
+        <Button
+          type="submit"
+          disabled={loading}
+          className="px-3 py-1 bg-green-700 text-white disabled:opacity-50"
+        >
+          {loading ? "Saving..." : submitLabel}
+        </Button>
+      </div>
+    </form>
+  );
+};


### PR DESCRIPTION
## Summary
- introduce `TaskForm` component for shared task form logic
- update `CreateTaskDialog` to use `TaskForm`
- update `EditTaskDialog` to use `TaskForm`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f34eb9f4c8333ab1a22079eceda83